### PR TITLE
feat(zsh): Add custom zsh plugins for pyenv, rbenv, and rust

### DIFF
--- a/shell/zsh/pyenv.zsh
+++ b/shell/zsh/pyenv.zsh
@@ -1,0 +1,3 @@
+if command -v pyenv 1>/dev/null 2>&1; then
+  eval "$(pyenv init -)"
+fi

--- a/shell/zsh/rbenv.zsh
+++ b/shell/zsh/rbenv.zsh
@@ -1,0 +1,3 @@
+if command -v rbenv 1>/dev/null 2>&1; then
+  eval "$(rbenv init -)"
+fi

--- a/shell/zsh/rust.zsh
+++ b/shell/zsh/rust.zsh
@@ -1,0 +1,2 @@
+# setup rust environment
+source $HOME/.cargo/env

--- a/zshrc
+++ b/zshrc
@@ -4,6 +4,8 @@ ANTIGEN_PATH="/usr/local/share/antigen"
 
 SHELL_PATH="$HOME/.shell"
 
+LOCAL_PLUGINS_PATH="$SHELL_PATH/zsh"
+
 OSX_APPLICATION_PATH="$HOME/Applications"
 
 LINUX_BREW_PATH="$HOME/.linuxbrew"
@@ -38,6 +40,7 @@ if [[ -d "$ANTIGEN_PATH" ]]; then
 
   antigen use oh-my-zsh
 
+  antigen bundle $LOCAL_PLUGINS_PATH
   antigen bundle brew
   antigen bundle common-aliases
   antigen bundle docker
@@ -47,8 +50,8 @@ if [[ -d "$ANTIGEN_PATH" ]]; then
   antigen bundle node
   antigen bundle npm
   antigen bundle nvm
-  antigen bundle pyenv
   antigen bundle osx
+  antigen bundle rust-lang/zsh-config
   antigen bundle zsh-users/zsh-syntax-highlighting
 
   antigen theme $ZSH_THEME


### PR DESCRIPTION
The `oh-my-zsh` plugin for pyenv is not configured the way I want it to be, and I also needed some simple stuff to support rust and ruby dev.

Changelog:

- Added a directory for local ZSH plugins with simple `pyenv`, `rbenv`, and `rust` plugins